### PR TITLE
Add admin create item spec

### DIFF
--- a/app/views/admin/items/_form.html.erb
+++ b/app/views/admin/items/_form.html.erb
@@ -5,17 +5,20 @@
       <%= f.collection_select :category_id, Category.all, :id, :name, {}, :class => 'collection_select' %>
     </div>
   </div>
-  <p>
-    <div class="control-group">
-      <%= f.label :retired, 'Item Status', :class => 'control-label' %>
-      <div class="controls" id='retired-status'>
-        <%= f.label 'retired_false', 'Active' %>
-        <%= f.radio_button :retired, false, :class => 'radio_button' %>
-        <%= f.label 'retired_true', 'Retired' %>
-        <%= f.radio_button :retired, true, :class => 'radio_button' %>
+  <% if is_new %>
+  <% else %>
+    <p>
+      <div class="control-group">
+        <%= f.label :retired, 'Item Status', :class => 'control-label' %>
+        <div class="controls" id='retired-status'>
+          <%= f.label 'retired_false', 'Active' %>
+          <%= f.radio_button :retired, false, :class => 'radio_button' %>
+          <%= f.label 'retired_true', 'Retired' %>
+          <%= f.radio_button :retired, true, :class => 'radio_button' %>
+        </div>
       </div>
-    </div>
-  </p>
+    </p>
+  <% end %>
   <p>
     <div class="control-group">
       <%= f.label :name, :class => 'control-label' %>

--- a/spec/features/admin_can_create_items_spec.rb
+++ b/spec/features/admin_can_create_items_spec.rb
@@ -1,23 +1,70 @@
-# As an authenticated Admin:
-# I can create an item.
-# - An item must have a title, description and price.
-# - An item must belong to at least one category.
-# - The title and description cannot be empty.
-# - The title must be unique for all items in the system.
-# - The price must be a valid decimal numeric value and greater than zero.
-# - The photo is optional. If not present, a stand-in photo is used. (PAPERCLIP)
 require 'rails_helper'
 
 RSpec.feature 'Admin can create an item' do
   scenario 'they can create an item with valid attributes' do
-    #code
+    category = Category.create!(name: 'weapons')
+    category = Category.create!(name: 'toys')
+    admin = User.create!(id: 1, username: 'Hodor', password: 'holddoor', address: 'The Woods', email: 'hold@thedoor.com', role: 1)
+
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
+
+    visit root_path
+
+    click_on 'Add an Item'
+
+    expect(current_path).to eq(new_admin_item_path)
+
+    select 'toys', from: 'Category'
+    fill_in 'Name', with: 'Direwolf Chew Toy'
+    fill_in 'Price', with: 14.99
+    fill_in 'Description', with: 'Give those loyal beasts something to play with.'
+    fill_in 'Image', with: 'http://zanydoodles.com/shop/images/bones.jpg'
+    click_button 'Submit'
+
+    expect(current_path).to eq('/items/1')
+    expect(page).to have_content('Direwolf Chew Toy')
+    expect(page).to have_content('$14.99')
+    expect(page).to have_content('Give those loyal beasts something to play with.')
+    expect(page).to have_css ('img[src="http://zanydoodles.com/shop/images/bones.jpg"]')
   end
 
   scenario 'they are redirected back to Create Item page if missing attributes' do
-    #code
+    category = Category.create!(name: 'weapons')
+    category = Category.create!(name: 'toys')
+    admin = User.create!(id: 1, username: 'Hodor', password: 'holddoor', address: 'The Woods', email: 'hold@thedoor.com', role: 1)
+
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
+
+    visit new_admin_item_path
+
+    select 'toys', from: 'Category'
+    fill_in 'Image', with: 'http://zanydoodles.com/shop/images/bones.jpg'
+    click_button 'Submit'
+
+    expect(current_path).to eq('/admin/items')
+    expect(page).to have_content("Name can't be blank. Price can't be blank. Price is not a number. Description can't be blank")
+    expect(page).to have_content('Create a New Item')
   end
 
   scenario 'a default image is applied if no image is provided' do
-    #code
+    category = Category.create!(name: 'weapons')
+    category = Category.create!(name: 'toys')
+    admin = User.create!(id: 1, username: 'Hodor', password: 'holddoor', address: 'The Woods', email: 'hold@thedoor.com', role: 1)
+
+    ApplicationController.any_instance.stubs(:current_user).returns(admin)
+
+    visit new_admin_item_path
+
+    select 'toys', from: 'Category'
+    fill_in 'Name', with: 'Frisbee'
+    fill_in 'Price', with: 15.99
+    fill_in 'Description', with: 'Toss it around.'
+    click_button 'Submit'
+
+    expect(current_path).to eq('/items/2')
+    expect(page).to have_content('Frisbee')
+    expect(page).to have_content('$15.99')
+    expect(page).to have_content('Toss it around.')
+    expect(page).to have_css ('img[src="http://thelivingroom.cafe/wp-content/uploads/2016/01/coming-soon-product-image.png"]')
   end
 end

--- a/spec/features/admin_can_edit_items_spec.rb
+++ b/spec/features/admin_can_edit_items_spec.rb
@@ -1,9 +1,3 @@
-# Background: an existing item
-# As an admin
-# When I visit "admin/items"
-# And I click "Edit"
-# Then my current path should be "/admin/items/:ITEM_ID/edit"
-# And I should be able to upate title, description, image, and status
 require 'rails_helper'
 
 RSpec.feature 'Admin can edit an existing item' do

--- a/spec/features/authenticated_user_can_view_previous_orders_spec.rb
+++ b/spec/features/authenticated_user_can_view_previous_orders_spec.rb
@@ -4,11 +4,11 @@ RSpec.feature 'authenticated user can view previous orders' do
   scenario 'they see their previous orders on the page' do
 
     category = Category.create!(name: 'weapons')
-    category.items.create!(name: 'Ice', img: 'http://www.valyriansteel.com/shop/images/uploads/ice-main.jpg', price: 0.99, description: "it's cold")
-    category.items.create!(name: 'Ice2', img: 'http://www.valyriansteel.com/shop/images/uploads/ice-main2.jpg', price: 2.99, description: "it's colder")
-    user = User.create!(username: 'ned', password: 'stark', email: 'raven@raven.net', address: 'winterfell')
+    category.items.create!(id: 15, name: 'Ice', img: 'http://www.valyriansteel.com/shop/images/uploads/ice-main.jpg', price: 0.99, description: "it's cold")
+    category.items.create!(id: 16, name: 'Ice2', img: 'http://www.valyriansteel.com/shop/images/uploads/ice-main2.jpg', price: 2.99, description: "it's colder")
+    user = User.create!(id: 1, username: 'ned', password: 'stark', email: 'raven@raven.net', address: 'winterfell')
     ApplicationController.any_instance.stubs(:current_user).returns(user)
-    cart = Cart.new({ '1' => 1, '2' => 2 })
+    cart = Cart.new({ '15' => 1, '16' => 2 })
     order = user.orders.create(amount: cart.total, status: 3)
     order.add_order_items(cart)
 

--- a/spec/models/cart_spec.rb
+++ b/spec/models/cart_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Cart, type: :model do
   end
 
   it 'should return the total cost of items in cart' do
-    Item.create!(name: 'Iron Throne', description: 'Would hurt to sit on', price: 20.00, img: 'image_url')
-    Item.create!(name: 'Dire Wolf', description: 'This wolf is in dire need of an owner', price: 10.00, img: 'image_url1')
-    Item.create!(name: 'Moon Door', description: 'A long fall comes before a long winter', price: 5.00, img: 'image_url2')
+    Item.create!(id: 12, name: 'Iron Throne', description: 'Would hurt to sit on', price: 20.00, img: 'image_url')
+    Item.create!(id: 13, name: 'Dire Wolf', description: 'This wolf is in dire need of an owner', price: 10.00, img: 'image_url1')
+    Item.create!(id: 14, name: 'Moon Door', description: 'A long fall comes before a long winter', price: 5.00, img: 'image_url2')
 
     cart = Cart.new({ '12' => 2, '13' => 1, '14' => 2 })
     expect(cart.total).to eq(60.00)
@@ -47,7 +47,7 @@ RSpec.describe Cart, type: :model do
   end
 
   it 'should return the number of a specific item' do
-    item = Item.create!(name: 'Steel Throne', description: 'Hurt to sit on', price: 200.00, img: 'image_url3')
+    item = Item.create!(id: 15, name: 'Steel Throne', description: 'Hurt to sit on', price: 200.00, img: 'image_url3')
     cart = Cart.new({ '15' => 3 })
 
     expect(cart.quantity(item)).to eq(3)


### PR DESCRIPTION
Finished testing admin items controller.
Added specs to test whether admin can create an item, and an image is defaulted to when one is not provided.
